### PR TITLE
Improve masking UX

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -164,15 +164,17 @@ function App() {
     <div className="app-card">
       <h1>Mask Face App</h1>
       <ImageUploader onChange={handleImageChange} loading={loading} />
-      <ImagePreview
-        imageUrl={imageUrl}
-        markers={markers}
-        imgRef={imgRef}
-        onLoad={handleImageLoad}
-        onUpdate={updateMarker}
-        onToggle={toggleMarker}
-        onClick={() => setMarkers(m => m)}
-      />
+      {!loading && (
+        <ImagePreview
+          imageUrl={imageUrl}
+          markers={markers}
+          imgRef={imgRef}
+          onLoad={handleImageLoad}
+          onUpdate={updateMarker}
+          onToggle={toggleMarker}
+          onClick={() => setMarkers(m => m)}
+        />
+      )}
       <Controls
         maskType={maskType}
         setMaskType={setMaskType}

--- a/src/components/Marker.jsx
+++ b/src/components/Marker.jsx
@@ -30,16 +30,25 @@ function makeDraggableResizable(el, onUpdate) {
     if (onUpdate) onUpdate(el)
   })
 
-  el.addEventListener('wheel', e => {
-    e.preventDefault()
-    let size = parseFloat(el.style.width)
-    size += e.deltaY < 0 ? 5 : -5
-    size = Math.max(10, size)
-    el.style.width = size + 'px'
-    el.style.height = size + 'px'
-    el.style.fontSize = size + 'px'
-    if (onUpdate) onUpdate(el)
-  })
+  el.addEventListener(
+    'wheel',
+    e => {
+      e.preventDefault()
+      e.stopPropagation()
+      const delta = e.deltaY < 0 ? 1 : -1
+      let size = parseFloat(el.style.width)
+      if (Number.isNaN(size)) {
+        size = el.getBoundingClientRect().width
+      }
+      size += delta * 5
+      size = Math.max(10, size)
+      el.style.width = size + 'px'
+      el.style.height = size + 'px'
+      el.style.fontSize = size + 'px'
+      if (onUpdate) onUpdate(el)
+    },
+    { passive: false }
+  )
 }
 
 function drawMosaicCanvas(canvas, image, pixel) {


### PR DESCRIPTION
## Summary
- hide the preview image while mask detection is in progress
- stabilize marker resizing via mouse wheel

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684ac62cadc88324bbcfa114d87f5f60