### PR TITLE
Fix marker sizing and wheel resize behavior

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -67,14 +67,19 @@ function App() {
     const scaleX = img.clientWidth / img.naturalWidth
     const scaleY = img.clientHeight / img.naturalHeight
     const newMarkers = detections.map(det => {
-      const { x, y, width } = det.detection.box
+      const { x, y, width, height } = det.detection.box
+      const cx = (x + width / 2) * scaleX
+      const cy = (y + height / 2) * scaleY
+      const size = Math.max(width * scaleX, height * scaleY) * 1.2
+      const left = cx - size / 2
+      const top = cy - size / 2
       if (maskType === 'mosaic') {
         return {
           id: nextId(),
           type: 'mosaic',
-          x: x * scaleX,
-          y: y * scaleY,
-          size: width * scaleX,
+          x: left,
+          y: top,
+          size,
           pixel: mosaicSize,
           dimmed: false
         }
@@ -86,9 +91,9 @@ function App() {
       return {
         id: nextId(),
         type: 'emoji',
-        x: x * scaleX,
-        y: y * scaleY,
-        size: width * scaleX,
+        x: left,
+        y: top,
+        size,
         emoji: expressionEmojiMap[best] || '😊',
         dimmed: false
       }
@@ -164,15 +169,17 @@ function App() {
     <div className="app-card">
       <h1>Mask Face App</h1>
       <ImageUploader onChange={handleImageChange} loading={loading} />
-      <ImagePreview
-        imageUrl={imageUrl}
-        markers={markers}
-        imgRef={imgRef}
-        onLoad={handleImageLoad}
-        onUpdate={updateMarker}
-        onToggle={toggleMarker}
-        onClick={() => setMarkers(m => m)}
-      />
+      {!loading && (
+        <ImagePreview
+          imageUrl={imageUrl}
+          markers={markers}
+          imgRef={imgRef}
+          onLoad={handleImageLoad}
+          onUpdate={updateMarker}
+          onToggle={toggleMarker}
+          onClick={() => setMarkers(m => m)}
+        />
+      )}
       <Controls
         maskType={maskType}
         setMaskType={setMaskType}


### PR DESCRIPTION
## Summary
- enlarge automatic marker size using face box dimensions
- hide preview while processing image
- avoid duplicated wheel listeners and make wheel resizing smoother

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ae1c202d8832494ac53c30592ec00