### PR TITLE
Hide preview until masking complete

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -38,6 +38,7 @@ function App() {
   const [markers, setMarkers] = useState([])
   const [loading, setLoading] = useState(false)
   const [imageUrl, setImageUrl] = useState(null)
+  const [processed, setProcessed] = useState(false)
   const [modelsLoaded, setModelsLoaded] = useState(false)
   const imgRef = useRef(null)
 
@@ -45,6 +46,7 @@ function App() {
     const file = e.target.files[0]
     if (!file) return
     setLoading(true)
+    setProcessed(false)
     setMarkers([])
     const form = new FormData()
     form.append('image', file)
@@ -99,6 +101,7 @@ function App() {
       }
     })
     setMarkers(newMarkers)
+    setProcessed(true)
     setLoading(false)
   }
 
@@ -176,6 +179,7 @@ function App() {
         onLoad={handleImageLoad}
         onUpdate={updateMarker}
         onToggle={toggleMarker}
+        processed={processed}
         onClick={() => setMarkers(m => m)}
       />
       <Controls

--- a/src/components/ImagePreview.jsx
+++ b/src/components/ImagePreview.jsx
@@ -1,21 +1,29 @@
 import React from 'react'
 import Marker from './Marker'
 
-export default function ImagePreview({ imageUrl, markers, imgRef, onLoad, onUpdate, onToggle, onClick }) {
+export default function ImagePreview({ imageUrl, markers, imgRef, onLoad, onUpdate, onToggle, onClick, processed }) {
   return (
     <div className="image-container" onClick={onClick}>
       {imageUrl && (
-        <img src={imageUrl} alt="uploaded" id="uploadedImage" onLoad={onLoad} ref={imgRef} />
-      )}
-      {markers.map(marker => (
-        <Marker
-          key={marker.id}
-          marker={marker}
-          uploadedImage={imgRef.current}
-          onUpdate={onUpdate}
-          onToggle={onToggle}
+        <img
+          src={imageUrl}
+          alt="uploaded"
+          id="uploadedImage"
+          onLoad={onLoad}
+          ref={imgRef}
+          style={{ visibility: processed ? 'visible' : 'hidden' }}
         />
-      ))}
+      )}
+      {processed &&
+        markers.map(marker => (
+          <Marker
+            key={marker.id}
+            marker={marker}
+            uploadedImage={imgRef.current}
+            onUpdate={onUpdate}
+            onToggle={onToggle}
+          />
+        ))}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add `processed` state to delay showing the uploaded image
- show image and markers only after face detection/masking finishes

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684b70457208832499a97468b29b568c